### PR TITLE
make to build on UNIX (tested on Ubuntu 21.10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/build/

--- a/include/compiler/SourceParser.h
+++ b/include/compiler/SourceParser.h
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <vector>
+#include "/usr/include/c++/11/cstring"
 
 #include "runtime/VirtualMachine.h"
 

--- a/include/compiler/SourceParser.h
+++ b/include/compiler/SourceParser.h
@@ -31,7 +31,7 @@
 
 #include <string>
 #include <vector>
-#include "/usr/include/c++/11/cstring"
+#include <cstring>
 
 #include "runtime/VirtualMachine.h"
 

--- a/include/runtime/VirtualMachine.h
+++ b/include/runtime/VirtualMachine.h
@@ -12,12 +12,13 @@
 #pragma once
 
 #include <vector>
+#include <cstdint>
 
 using namespace std;
 
 namespace vm {
 
-	typedef __int32 WORD;
+	typedef int32_t WORD;
 
 	constexpr WORD OP_CODE_MASK = 0b00000000000000000000000011111111;
 	constexpr WORD OP_TYPE_MASK = 0b00000000000000000000111000000000;

--- a/src/cvm.cpp
+++ b/src/cvm.cpp
@@ -71,10 +71,16 @@ void compileRun(string filepath, bool showTree, bool showSymbols, bool disassemb
 }
 
 
-int main()
-{
+int main(int argc, char** argv){
+	  if(argc < 1){
+		  puts("No filename was given.");
+		  return 1;
+	  }
+
+
+	compileRun(*(argv + 1), true, true, true, true);
 	//compileRun("../../../test/factorial.cvm", true, true, true, true);
-	compileRun("../../../test/primenumber.cvm", true, true, true, true);
+	//compileRun("../../../test/primenumber.cvm", true, true, true, true);
 	//compileRun("../../../test/combinatorics.cvm", true, true, true, true);
 	//compileRun("../../../test/scope.cvm", true, true, true, true);
 	return 0;


### PR DESCRIPTION
I made a fork and finished it. Now it can be run under Ubuntu. I'll try to insert it into ESP at the weekend. I'm sending a PULL here so you can see the changes I've made. it's just a couple of includes and type definitions. I am attaching the output from the console to verify the result:

```
denis@denis-OMEN:~/projects/CVM/build/default$ ./cvm ../../test/factorial.cvm 
Current path: "/home/denis/projects/CVM/build/default"
-----------------------------------------------------
Parsed abstract syntax tree
-----------------------------------------------------
''(MODULE) GLOBAL
|-'fact'(FUNCTION) GLOBAL
| |-'int'(TYPE) GLOBAL
| |-''(SYMBOL) fact
| | |-'int'(TYPE) fact
| | | |-'n'(SYMBOL) fact
| |-'BLOCK'(BLOCK) fact
| | |-'int'(TYPE) fact
| | | |-'x'(SYMBOL) fact
| | |-'if'(IF_ELSE) fact
| | | |-'n'(SYMBOL) fact
| | | |-'BLOCK'(BLOCK) block0
| | | | |-'='(ASSIGNMENT) block0
| | | | | |-'x'(SYMBOL) block0
| | | | | |-'*'(BINARY_OP) block0
| | | | | | |-'n'(SYMBOL) block0
| | | | | | |-'fact'(CALL) block0
| | | | | | | |-'-'(BINARY_OP) block0
| | | | | | | | |-'n'(SYMBOL) block0
| | | | | | | | |-'1'(CONSTANT) block0
| | | | |-'return'(RETURN) block0
| | | | | |-'x'(SYMBOL) block0
| | | |-'BLOCK'(BLOCK) block1
| | | | |-'='(ASSIGNMENT) block1
| | | | | |-'x'(SYMBOL) block1
| | | | | |-'10'(CONSTANT) block1
| | | | |-'return'(RETURN) block1
| | | | | |-'1'(CONSTANT) block1
| | |-'return'(RETURN) fact
| | | |-'0'(CONSTANT) fact
|-'main'(FUNCTION) GLOBAL
| |-'int'(TYPE) GLOBAL
| |-''(SYMBOL) main
| |-'BLOCK'(BLOCK) main
| | |-'int'(TYPE) main
| | | |-'n'(SYMBOL) main
| | | |-'i'(SYMBOL) main
| | |-'='(ASSIGNMENT) main
| | | |-'i'(SYMBOL) main
| | | |-'1'(CONSTANT) main
| | |-'while'(WHILE) main
| | | |-'<='(BINARY_OP) main
| | | | |-'i'(SYMBOL) main
| | | | |-'100'(CONSTANT) main
| | | |-'BLOCK'(BLOCK) block2
| | | | |-'if'(IF_ELSE) block2
| | | | | |-'<'(BINARY_OP) block2
| | | | | | |-'i'(SYMBOL) block2
| | | | | | |-'12'(CONSTANT) block2
| | | | | |-'BLOCK'(BLOCK) block3
| | | | | | |-'='(ASSIGNMENT) block3
| | | | | | | |-'n'(SYMBOL) block3
| | | | | | | |-'fact'(CALL) block3
| | | | | | | | |-'i'(SYMBOL) block3
| | | | | | |-'iput'(CALL) block3
| | | | | | | |-'n'(SYMBOL) block3
| | | | | | |-'='(ASSIGNMENT) block3
| | | | | | | |-'i'(SYMBOL) block3
| | | | | | | |-'+'(BINARY_OP) block3
| | | | | | | | |-'i'(SYMBOL) block3
| | | | | | | | |-'1'(CONSTANT) block3
| | | | | |-'break'(BREAK) block2
| | |-'return'(RETURN) main
| | | |-'n'(SYMBOL) main
-----------------------------------------------------
Symbol table
-----------------------------------------------------
GLOBAL:
iput    FUNCTION at [0] args=1
iget    FUNCTION at [0] args=1
fact    FUNCTION at [4] args=1
main    FUNCTION at [38] args=0
        fact:
        n       ARGUMENT #0
        x       VARIABLE #0
                block0:
                block1:
        main:
        n       VARIABLE #0
        i       VARIABLE #1
                block2:
                        block3:
-----------------------------------------------------
Virtual machine executable image disassembly
-----------------------------------------------------
[     0]    call    [38], 0
[     3]    ---- halt ----
[     4]    iconst  0
[     6]    iarg    #0
[     8]    ifzero  [+19]
[    10]    iarg    #0
[    12]    iarg    #0
[    14]    iconst  1
[    16]    isub    
[    17]    call    [4], 1
[    20]    imul    
[    21]    istore  #0
[    23]    iload   #0
[    25]    ret     
[    26]    jmp     [+8]
[    28]    iconst  10
[    30]    istore  #0
[    32]    iconst  1
[    34]    ret     
[    35]    iconst  0
[    37]    ret     
[    38]    iconst  0
[    40]    iconst  0
[    42]    iconst  1
[    44]    istore  #1
[    46]    iload   #1
[    48]    iconst  100
[    50]    lsequal  
[    51]    ifzero  [+32]
[    53]    iload   #1
[    55]    iconst  12
[    57]    less     
[    58]    ifzero  [+21]
[    60]    iload   #1
[    62]    call    [4], 1
[    65]    istore  #0
[    67]    iload   #0
[    69]    syscall 0x21
[    71]    iload   #1
[    73]    iconst  1
[    75]    iadd    
[    76]    istore  #1
[    78]    jmp     [+3]
[    80]    jmp     [+3]
[    82]    jmp     [-37]
[    84]    iload   #0
[    86]    ret     
-----------------------------------------------------
Virtual machine runtime
-----------------------------------------------------
1
2
6
24
120
720
5040
40320
362880
3628800
39916800
VM: IP=4 FP=16383 LP=16382 SP=16382 STACK=[39916800] -> TOP
Execution time: 6.3904e-05s
denis@denis-OMEN:~/projects/CVM/build/default$ git 
```

Compiled without CMake modifications.